### PR TITLE
[WIP] Add support for macrocalls and for begin ... end blocks.

### DIFF
--- a/src/Lazy.jl
+++ b/src/Lazy.jl
@@ -16,23 +16,26 @@ end
 
 # Threading macros
 
-macro >(x, expr, exprs...)
-  if typeof(expr) == Expr && expr.head == :tuple
-    return Expr(:macrocall, symbol("@>"), esc(x), map(esc,expr.args)..., map(esc,exprs)...)
+thread_left(x) = thread_left(filter(x-> !isa(x,Expr) || x.head != :line, x.args)...)
 
-  elseif typeof(expr) == Symbol
-    call = esc(Expr(:call, expr, x))
+function thread_left(x, expr, exprs...)
+  if typeof(expr) == Symbol
+    call = Expr(:call, expr, x)
 
-  elseif typeof(expr) == Expr && expr.head == :call
-    call = esc(Expr(:call, expr.args[1], x, expr.args[2:]...))
+  elseif typeof(expr) == Expr && expr.head in [:call, :macrocall]
+    call = Expr(expr.head, expr.args[1], x, expr.args[2:]...)
 
   elseif typeof(expr) == Expr && expr.head == :->
-    call = esc(Expr(:call, expr, x))
+    call = Expr(:call, expr, x)
 
   else
     error("Unsupported expression $expr in @>")
   end
-  isempty(exprs) ? call : :(@> $call $(map(esc,exprs)...))
+  isempty(exprs) ? call : :(@> $call $(exprs...))
+end
+
+macro >(exprs...)
+    esc(thread_left(exprs...))
 end
 
 macro >>(x, expr, exprs...)


### PR DESCRIPTION
This pull request adds support for macro calls (`@mymacro(a, b)`). It also adds support for blocks as follows:

``` julia
x = @> begin
    [1,2,3]
    x -> x + 2
    sum
end
```

More examples of this are here: https://github.com/JuliaStats/DataFramesMeta.jl/pull/3

It's a work in progress because it doesn't include matching updates for `@>>` and because I wasn't sure what the following lines did, so I deleted them:

``` julia
  if typeof(expr) == Expr && expr.head == :tuple
    return Expr(:macrocall, symbol("@>"), esc(x), map(esc,expr.args)..., map(esc,exprs)...)
```
