### PR TITLE
Fix '=>' precedence and shadowed exports.

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -226,7 +226,7 @@ Also supports if-else chains via ternary or block syntax.
 """
 macro cond(ex)
   @match ex begin
-    (c_ ? y_ : n_) => eval(current_module(), c) ? esc(y) : :(@cond $(esc(n)))
+    (c_ ? y_ : n_) => (eval(current_module(), c) ? esc(y) : :(@cond $(esc(n))))
     _ => esc(ex)
   end
 end

--- a/src/tail.jl
+++ b/src/tail.jl
@@ -8,8 +8,8 @@ function lastcalls(ex, f)
     begin __ end   => :(begin $(lastcalls(ex.args, f)...) end)
     let __ end     => :(let $(lastcalls(ex.args, f)...) end)
     (c_ ? y_ : n_) => :($c ? $(lastcalls(y, f)) : $(lastcalls(n, f)))
-    a_ && b_       => :($a && $(lastcalls(b, f)))
-    a_ || b_       => :($a || $(lastcalls(b, f)))
+    (a_ && b_)     => :($a && $(lastcalls(b, f)))
+    (a_ || b_)     => :($a || $(lastcalls(b, f)))
     _              => ex
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Lazy
+import Lazy: rest, cycle, range, drop, take
 using FactCheck
 
 facts("Lists") do


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/12285 changed the precedence of ``=>`` which now requires a couple of extra ``(...)``. Also added some explicit imports to the test file since they seem to be shadowed by exports from ``Base``.