### PR TITLE
remove the underscores to unify the function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,11 @@ riffle
 interpose
 take
 drop
-take_last
-drop_last
-take_nth
-take_while
-drop_while
+takelast
+droplast
+takenth
+takewhile
+dropwhile
 # These work as for arrays, but are
 # lazy where appropriate.
 map, reduce, filter, reverse
@@ -185,11 +185,11 @@ remove
 dorun
 foreach
 distinct
-group_by
+groupby
 partition
-partition_by
-split_at
-split_by
+partitionby
+splitat
+splitby
 
 # @lazy is the secret sauce that makes infinite definitions
 # work; usually you can just wrap your list definition in it:

--- a/src/Lazy.jl
+++ b/src/Lazy.jl
@@ -142,7 +142,7 @@ const fibs = @lazy 0:big(1):(fibs + drop(1, fibs))
 
 isprime(n) =
   @>> primes begin
-    take_while(x -> x<=sqrt(n))
+    takewhile(x -> x<=sqrt(n))
     map(x -> n % x == 0)
     any; !
   end


### PR DESCRIPTION
Remove the underscores in the following functions, 
```
take_last
drop_last
take_nth
take_while
drop_while
partition_by
split_at
split_by
group_by
```