### PR TITLE
fix rest(l::LazyList) to return LazyList instead of LinkedList

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Firstly, the canonical examples, in Julia:
 ```julia
 # Note : prepends. Don't forget the semicolon!
 # Fibonacci sequence defined in terms of itself:
-fibs = @lazy 0:1:(fibs + drop(1, fibs));
+fibs = @lazy 0:big(1):(fibs + drop(1, fibs));
+# or
+fibs = @lazy 0:big(1):(fibs + rest(fibs));
 
 take(20, fibs)
 #> (0 1 1 2 3 5 8 13 21 34 55 89 144 233 377 610 987 1597 2584 4181)

--- a/src/Lazy.jl
+++ b/src/Lazy.jl
@@ -71,16 +71,18 @@ isempty(::LinkedList) = false
 
 # Lazy Lists
 
-realise(xs::LazyList) =
-  xs.realised? xs.list : (xs.realised = true; xs.list = xs.f())
-
-for f in [:first :rest :isempty]
-  @eval $f(l::LazyList) = $f(realise(l))
-end
-
 macro lazy(code)
   :(LazyList(() -> seq($(esc(code)))))
 end
+
+realise(xs::LazyList) =
+  xs.realised? xs.list : (xs.realised = true; xs.list = xs.f())
+
+for f in [:first :isempty]
+  @eval $f(l::LazyList) = $f(realise(l))
+end
+
+rest(l::LazyList) = @lazy rest(realise(l))
 
 ########
 # Usage

--- a/src/Lazy.jl
+++ b/src/Lazy.jl
@@ -81,7 +81,7 @@ realise(xs::LazyList) =
 for f in [:first :isempty]
   @eval $f(l::LazyList) = $f(realise(l))
 end
-
+#
 rest(l::LazyList) = @lazy rest(realise(l))
 
 ########


### PR DESCRIPTION
Currently, `rest(l::LazyList)` returns a LinkedList but it is more reasonable to return a LazyList, for example the following code works unexpectedly due to the fact that `rest(l::LazyList)` returns a LinkedList,
```
fibs = @lazy 0:1:(fibs + rest(fibs));
take(10, fibs)
```
only 0, 1 are returned

and the code works well after the returning type is changed to LazyList