### PR TITLE
Better error messages in tupleassign

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.15.1"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [compat]
 MacroTools = "0.4.4, 0.5"

--- a/src/tail.jl
+++ b/src/tail.jl
@@ -34,7 +34,7 @@ export @rec, @bounce
 "Generate an expression like `(a, b) = (c, d)`."
 tupleassign(xs, ys) = quote
   begin
-    if length(xs) < length(ys)
+    if length($xs) < length($ys)
       @warn """
       @rec: [tupleassign] Extra arguments passed in recursive calls will be ignored
         > `Lazy.@rec` keeps track of arguments in a tuple, and your recursive

--- a/src/tail.jl
+++ b/src/tail.jl
@@ -34,29 +34,32 @@ export @rec, @bounce
 "Generate an expression like `(a, b) = (c, d)`."
 tupleassign(xs, ys) = quote
   begin
-    if length($xs) < length($ys)
-      @warn """
-      @rec: [tupleassign] Extra arguments passed in recursive calls will be ignored
-        > `Lazy.@rec` keeps track of arguments in a tuple, and your recursive
-        > call passed extra arguments to the function. This will result (after
-        > macro expansion) in a snippet like `(arg1, arg2) = (rec1, rec2, rec3)`
-        > Julia allows you to do this (`rec3` will be ignored), but in this case
-        > it is most likely a mistake.
-      """
-    end
-    try
+    (xs__tailrec_tupleassign, ys__tailrec_tupleassign) = ($xs, $ys)
+    (xslen__tailrec_tupleassign, yslen__tailrec_tupleassign) = (
+      length($xs), length($ys)
+    )
+    if xslen__tailrec_tupleassign > yslen__tailrec_tupleassign
+      error("""
+      @rec: [tupleassign] Wrong number of arguments passed in tail-recursive calls
+        (Tuple$(xslen__tailrec_tupleassign)...) = (Tuple$(yslen__tailrec_tupleassign)...)
+        $xs__tailrec_tupleassign = $ys__tailrec_tupleassign
+      """)
+    else
+      if xslen__tailrec_tupleassign < yslen__tailrec_tupleassign
+        @warn """
+        @rec: [tupleassign] Extra arguments passed in recursive calls will be ignored
+          > `Lazy.@rec` keeps track of arguments in a tuple, and your recursive
+          > call passed extra arguments to the function. This will result (after
+          > macro expansion) in a snippet like `(arg1, arg2) = (rec1, rec2, rec3)`
+          > Julia allows you to do this (`rec3` will be ignored), but in this case
+          > it is most likely a mistake.
+        """
+      end
       $(Expr(:(=), Expr(:tuple, xs...), Expr(:tuple, ys...)))
-    catch exception__tailrec_tupleassign
-      error(
-        if isa(exception__tailrec_tupleassign, BoundsError)
-          "@rec: [tupleassign] Wrong number of arguments passed in tail-recursive calls"
-        else
-          "@rec: [tupleassign] Unexpected exception (not BoundsError)"
-        end
-      )
     end
   end
 end
+
 
 
 tco(ex, f, dummy, start) =

--- a/src/tail.jl
+++ b/src/tail.jl
@@ -1,5 +1,7 @@
 using MacroTools
 
+import Logging.@warn
+
 # Tail call operations
 
 function lastcalls(f, ex)
@@ -30,7 +32,32 @@ tailcalls(f, ex) = @>> ex lastcalls(f) retcalls(f)
 export @rec, @bounce
 
 "Generate an expression like `(a, b) = (c, d)`."
-tupleassign(xs, ys) = Expr(:(=), Expr(:tuple, xs...), Expr(:tuple, ys...))
+tupleassign(xs, ys) = quote
+  begin
+    if length(xs) < length(ys)
+      @warn """
+      @rec: [tupleassign] Extra arguments passed in recursive calls will be ignored
+        > `Lazy.@rec` keeps track of arguments in a tuple, and your recursive
+        > call passed extra arguments to the function. This will result (after
+        > macro expansion) in a snippet like `(arg1, arg2) = (rec1, rec2, rec3)`
+        > Julia allows you to do this (`rec3` will be ignored), but in this case
+        > it is most likely a mistake.
+      """
+    end
+    try
+      $(Expr(:(=), Expr(:tuple, xs...), Expr(:tuple, ys...)))
+    catch exception__tailrec_tupleassign
+      error(
+        if isa(exception__tailrec_tupleassign, BoundsError)
+          "@rec: [tupleassign] Wrong number of arguments passed in tail-recursive calls"
+        else
+          "@rec: [tupleassign] Unexpected exception (not BoundsError)"
+        end
+      )
+    end
+  end
+end
+
 
 tco(ex, f, dummy, start) =
   @capture(ex, $f(args__)) ?


### PR DESCRIPTION
Right now, if a user passes the wrong number of arguments, one of two things can happen:

1. Too few arguments provided: a somewhat confusing BoundsError without context.
2. Too many arguments provided: the remaining ones will be ignored, which can cause a ton of subtle issues.

This is what I came up with:

1. In addition to showing the BoundsError, it also gives the error below.

```julia
"""
@rec: [tupleassign] Wrong number of arguments passed in tail-recursive calls
    (Tuple8...) = (Tuple7...)
    (a, b, c, d, e, f, g, h) = (1, 2, 3, 4, 5, 6, 7)
"""
```

2. I didn't want to break backwards compatibility, because some people might actually use this feature. This will still work, but it will give a (hopefully) helpful warning explaining what is going on and that this is probably a bad idea.

```julia
@warn """
@rec: [tupleassign] Extra arguments passed in recursive calls will be ignored
  > `Lazy.@rec` keeps track of arguments in a tuple, and your recursive
  > call passed extra arguments to the function. This will result (after
  > macro expansion) in a snippet like `(arg1, arg2) = (rec1, rec2, rec3)`
  > Julia allows you to do this (`rec3` will be ignored), but in this case
  > it is most likely a mistake.
"""
```

It took me forever to figure out what was going on when I made this mistake, and so hopefully this can help out. 

Note: The warning bit does require the `Logging` dependency:
```julia
import Logging.@warn
```
